### PR TITLE
fix: added support for OK-BUT successful messages from Etherscan

### DIFF
--- a/src/hooks/useTransactionList.ts
+++ b/src/hooks/useTransactionList.ts
@@ -15,7 +15,7 @@ const fetchTransactionList = address => async ({ account }) => {
     throw new Error(`Expected ${TYPEDEF_TRANSACTION_LIST}, encountered ${data}.`);
   }
   const { message, result } = data;
-  if (message !== "OK") {
+  if (!message.startsWith("OK")) {
     throw new Error(JSON.stringify(data));
   }
   return result;


### PR DESCRIPTION
Hey!

Thanks for creating this library.

I noticed that there are Etherscan responses which return `OK` combined with a message, for example: http://api.etherscan.io/api?module=account&action=txlist&address=0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a&startblock=0&endblock=99999999&sort=asc&apikey=YourApiKeyToken.

Extending this to support that use case.